### PR TITLE
Update path to hook function

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,22 +55,37 @@ Note that an exception will be thrown on compilation if the resource is unavaila
 #### source (either `url`, `file`, or `data`)
 The json resource to request.
 
-#### path
-A specific key from the requested json to be used.  For example, let's say your json is an object like this:
+#### hook
+A function that is passed in the JSON data for your record and allows you to manipulate the data before your templates are compiled. Whatever this function returns will be set for your record's key.
+
+For example, with the following hook function:
 
 ```coffee
-{
- kind: "books",
- items: [
-    {
-      title: "The Great Gatsby",
-      author: "F. Scott Fitzgerald"
+extensions: [
+  records({
+    books: {
+      data: {
+        foo: "bar"
+      }, 
+      hook: (obj) ->
+        obj.foo = "doge"
+        return obj
     }
-  ]
-}
+  })
+]
 ```
 
-If you want to simply use the value of `"items"`, pass `"items"` to the `path` option, and your record will simply be the `items` array.
+And the following template:
+
+```jade
+h1= records.books.foo
+```
+
+Should result in an output of the following:
+
+```html
+<h1>doge</h1>
+```
 
 ### Templates
 

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -104,21 +104,8 @@ module.exports = (opts) ->
      ###
 
     respond = (key, obj, response) ->
-      @roots.config.locals.records[key] = to response, obj.path
-
-    ###*
-     * Navigates object based on "path."
-     * ex: 'book/items' returns obj['books']['items']
-     * @param {String} object - the object to be navigated
-     * @param {Object} path - the path to the desired value.
-     ###
-
-    to = (object, path) ->
-      if not path then return object
-      keys = path.split "/"
-      pos = object
-      pos = pos[key] for key in keys when pos[key]?
-      pos
+      response = if obj.hook then obj.hook(response) else response
+      @roots.config.locals.records[key] = response
 
     __parse = (response, resolver) ->
       try

--- a/test/fixtures/roots/data_hook/app.coffee
+++ b/test/fixtures/roots/data_hook/app.coffee
@@ -1,0 +1,20 @@
+records = require '../../../..'
+
+module.exports =
+  ignores: ["**/_*"]
+
+  extensions: [
+    records({
+      books: {
+        data: {
+          foo: "bar"
+        }, 
+        hook: (obj) ->
+          obj.foo = "doge"
+          return obj
+      }
+    })
+  ]
+
+  jade:
+    pretty: true

--- a/test/fixtures/roots/data_hook/index.jade
+++ b/test/fixtures/roots/data_hook/index.jade
@@ -1,0 +1,1 @@
+!= JSON.stringify(records.books)

--- a/test/fixtures/roots/data_hook/package.json
+++ b/test/fixtures/roots/data_hook/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test",
+  "dependencies": {
+    "jade": "*"
+  }
+}

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -13,6 +13,7 @@ _projects  = {
   url: path.join(_roots, "url"),
   file: path.join(_roots, "file"),
   data: path.join(_roots, "data"),
+  data_hook: path.join(_roots, "data_hook"),
   invalid_key: path.join(_roots, "invalid_key"),
   invalid_url: path.join(_roots, "invalid_url"),
   invalid_file: path.join(_roots, "invalid_file")
@@ -109,3 +110,10 @@ describe 'records', ->
       new Roots(_projects.invalid_file).compile()
         .catch(should.exist)
         .done(done())
+
+  describe 'data hook', ->
+    before (done) ->
+      @_ = init_roots _projects.data_hook, done
+
+    it 'should call the hook fn to manipulate the data before passing into views', ->
+      @_.helpers.file.contains(path.join("public", "index.html"), JSON.stringify({foo: 'doge'})).should.be.ok


### PR DESCRIPTION
This replaces the `path` option with a `hook` option that takes a function. The function takes in your record's data and allows you to manipulate it however you please. Whatever is returned from this function is then set as your `records.<key>`. This makes the extension more flexible and removes some of the parsing logic needed for the `path` option.