### PR TITLE
updates roots-records for roots v3.0.0-rc.11 & accord v0.13.0

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -131,7 +131,7 @@ module.exports = (opts) ->
         compiler = _.find @roots.config.compilers, (c) ->
           _.contains(c.extensions, path.extname(template).substring(1))
         compiler.renderFile(template, @roots.config.locals)
-          .then((res) => @util.write("#{out_fn(item)}.html", res))
+          .then((res) => @util.write("#{out_fn(item)}.html", res.result))
 
     __parse = (response, resolver) ->
       try

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "coffee-script": "1.7.x",
-    "roots": "3.0.0-rc.10",
+    "roots": "3.0.x",
     "roots-util": "0.1.x",
     "mocha": "*",
     "should": "*",


### PR DESCRIPTION
this updates for a breaking change introduced in [roots v3.0.0-rc.11](https://github.com/jenius/roots/releases/tag/v3.0.0-rc.11) caused by a change in [accord v0.13.0](https://github.com/jenius/accord/releases/tag/v0.13.0)