### PR TITLE
Changing the Single View compile to respect app.coffee adapter config

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -132,7 +132,8 @@ module.exports = (opts) ->
         _path = "/#{compiled_file_path.replace(path.sep, '/')}"
         compiler = _.find @roots.config.compilers, (c) ->
           _.contains(c.extensions, path.extname(template).substring(1))
-        compiler.renderFile(template, _.extend(@roots.config.locals, _path: _path))
+        compiler_options = @roots.config[compiler.name] ? {}
+        compiler.renderFile(template, _.extend(@roots.config.locals, compiler_options, _path: _path))
           .then((res) => @util.write(compiled_file_path, res.result))
 
     __parse = (response, resolver) ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -134,6 +134,9 @@ describe 'records', ->
     it 'should pass the _path view helper for that single view', ->
       @_.helpers.file.contains(@test_path, '/books/to-kill-a-mockingbird.html')
 
+    it "should use the adapter config settings like 'pretty:true'", ->
+      @_.helpers.file.contains(@test_path, '\n').should.be.true
+
     it 'should throw an error if collection is not an array', (done) ->
       new Roots(_projects.invalid_collection).compile()
         .catch(should.exist)


### PR DESCRIPTION
While generating some pages using Single Views I noticed that the resulting pages did not respect my Jade setting of `pretty:true`.

This small change aims to ensure that adapter settings within the app.coffee files are taken into account when items are compiled via Single Views.