### PR TITLE
Adding dynamic template paths to Single Views

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -44,8 +44,7 @@ module.exports = (opts) ->
           respond.call @, key, obj, response
         .then (response) =>
           if obj.template
-            template = path.join(@roots.root, obj.template)
-            compile_single_views.call(@, obj.collection(response), template, obj.out)
+            compile_single_views.call(@, obj.collection(response), obj.template, obj.out)
 
     ###*
      * Determines and calls the appropriate function
@@ -128,11 +127,12 @@ module.exports = (opts) ->
       if not _.isArray(collection) then throw new Error "collection must return an array"
       W.map collection, (item) =>
         @roots.config.locals.item = item
+        template_path = path.join(@roots.root, if _.isFunction(template) then template(item) else template);
         compiled_file_path = "#{out_fn(item)}.html"
         _path = "/#{compiled_file_path.replace(path.sep, '/')}"
         compiler = _.find @roots.config.compilers, (c) ->
-          _.contains(c.extensions, path.extname(template).substring(1))
-        compiler.renderFile(template, _.extend(@roots.config.locals, _path: _path))
+          _.contains(c.extensions, path.extname(template_path).substring(1))
+        compiler.renderFile(template_path, _.extend(@roots.config.locals, _path: _path))
           .then((res) => @util.write(compiled_file_path, res.result))
 
     __parse = (response, resolver) ->

--- a/test/fixtures/roots/single_view/app.coffee
+++ b/test/fixtures/roots/single_view/app.coffee
@@ -26,6 +26,25 @@ module.exports =
             }
           ]
         }
+      },
+      tvshows: {
+        out: (tvshow) -> "/tvshows/#{S(tvshow.title).slugify().s}"
+        collection: (d) -> d.response
+        template: (tvshow) ->
+          if tvshow.template then "views/_tvshow_#{tvshow.template}.jade" else "views/_tvshow.jade"
+        data: {
+          response: [
+            {
+              title: 'The Lost Room'
+              year: '2006'
+            },
+            {
+              title: 'Fringe'
+              year: '2008',
+              template: 'dynamic'
+            }
+          ]
+        }
       }
     })
   ]

--- a/test/fixtures/roots/single_view/views/_tvshow.jade
+++ b/test/fixtures/roots/single_view/views/_tvshow.jade
@@ -1,0 +1,4 @@
+h1= item.title
+h2= item.year
+h3= _path
+h4 default

--- a/test/fixtures/roots/single_view/views/_tvshow_dynamic.jade
+++ b/test/fixtures/roots/single_view/views/_tvshow_dynamic.jade
@@ -1,0 +1,4 @@
+h1= item.title
+h2= item.year
+h3= _path
+h4 dynamic

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -124,6 +124,7 @@ describe 'records', ->
     before (done) ->
       @_ = init_roots _projects.single_view, done
       @test_path = path.join("public", "books", "to-kill-a-mockingbird.html")
+      @test_path_dynamic = path.join("public", "tvshows", "fringe.html")
 
     it 'should compile a single page view', ->
       @_.helpers.file.exists(@test_path).should.be.true
@@ -133,6 +134,9 @@ describe 'records', ->
 
     it 'should pass the _path view helper for that single view', ->
       @_.helpers.file.contains(@test_path, '/books/to-kill-a-mockingbird.html')
+
+    it 'should compile with a dynamic template path', ->
+      @_.helpers.file.contains(@test_path_dynamic, 'dynamic').should.be.true
 
     it 'should throw an error if collection is not an array', (done) ->
       new Roots(_projects.invalid_collection).compile()


### PR DESCRIPTION
This adjustment adds a new feature whereby the template to be used for the output of a Single View can be supplied as a function, allowing it to be determined on a per-item basis (in the same fashion as the output paths).