### PR TITLE
Pass in proper conf object into client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 public
+coverage

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -65,7 +65,11 @@ module.exports = (opts) ->
         .wrap(mime)
         .wrap(error_code)
 
-      conf = if typeof opts.url is 'string' then { path: opts.url } else opts
+      if typeof opts.url is 'string'
+        conf = { path: opts.url }
+      else
+        conf = opts.url
+
       client(conf).then (res) ->
         if not res.entity
           throw new Error("URL has not returned any content")

--- a/test/fixtures/url/app.coffee
+++ b/test/fixtures/url/app.coffee
@@ -6,6 +6,11 @@ module.exports =
   extensions: [
     records(
       books: { url: 'https://www.googleapis.com/books/v1/volumes?q=The+Great+Gatsby'}
+      books_with_options: {
+        url:
+          path: 'https://www.googleapis.com/books/v1/volumes?q=The+Great+Gatsby'
+          method: 'GET'
+      }
     )
   ]
 

--- a/test/fixtures/url/index_with_options.jade
+++ b/test/fixtures/url/index_with_options.jade
@@ -1,0 +1,1 @@
+!= JSON.stringify(records.books_with_options)

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -32,11 +32,24 @@ describe 'url', ->
 
 describe 'url with http options', ->
 
+  it 'should pass the right path with option', (done) ->
+    compile_fixture.call @, 'url', =>
+      index_path = path.join(_path, @public, 'index_with_options.html')
+      json = JSON.parse(fs.readFileSync(index_path, 'utf8'))
+
+      json.should.be.a('object')
+      json.items.should.exist
+      json.items.length.should.equal(10)
+
+      done()
+
   it 'should POST request and generate an error', (done) ->
     project = new Roots(path.join(_path, 'url_options'))
     project.on('error', ->)
     project.compile().catch (res) ->
-      if res.error.code is 'ECONNREFUSED' then done() else done(res)
+      res.status.code.should.equal(404)
+
+      done()
 
 describe 'file', ->
 


### PR DESCRIPTION
If `url` is not a string, we need to pass in `opts.url`, which contains the `path` as well as other props used by the `rest` client.
resolves issue: https://github.com/carrot/roots-records/issues/25