### PR TITLE
Update index.coffee with a write_hook for exporting json

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -115,7 +115,7 @@ module.exports = (opts) ->
       return obj
 
     ###*
-     * If a write string option was provided in the config, write out the 
+     * If a write string option was provided in the config, write out the
      * retrieved data to the configured file for later usage in the generated
      * site
      *
@@ -126,7 +126,7 @@ module.exports = (opts) ->
       if not obj.options.write then return
       # Maybe one needs it not only for urls - so ignore this check
       # if not obj.options.url then throw new Error("Writing fetched JSON Data
-      # to a file does only make sense on urls, he? So please provide a 'url' 
+      # to a file does only make sense on urls, he? So please provide a 'url'
       # option")
       return this.util.write(opts.write, JSON.stringify(obj.data))
 

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -113,8 +113,11 @@ module.exports = (opts) ->
       if not obj.options.hook then return obj
       obj.data = obj.options.hook(obj.data)
       return obj
+
     ###*
-     * If a write string option was provided in the config, write out the retrieved data to the configured file for later usage in the generated site.
+     * If a write string option was provided in the config, write out the 
+     * retrieved data to the configured file for later usage in the generated
+     * site
      *
      * @param {String} obj - record object with a `key`, `options`, and `data`
      ###
@@ -122,8 +125,10 @@ module.exports = (opts) ->
     write_hook = (obj) ->
       if not obj.options.write then return
       # Maybe one needs it not only for urls - so ignore this check
-      # if not obj.options.url then throw new Error("Writing fetched JSON Data to a file does only make sense on urls, he? So please provide a 'url' option")
-      return this.util.write(opts.write, JSON.stringify(obj.data));
+      # if not obj.options.url then throw new Error("Writing fetched JSON Data
+      # to a file does only make sense on urls, he? So please provide a 'url' 
+      # option")
+      return this.util.write(opts.write, JSON.stringify(obj.data))
 
     ###*
      * Given a resolved records object, adds it to the view's locals.

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -31,6 +31,7 @@ module.exports = (opts) ->
       W.all(fetch_records)
         .then (res) -> W.map(res, apply_hook)
         .tap (res) => W.map(res, add_to_locals.bind(@))
+        .tap (res) => W.map(res, write_hook.bind(@))
         .tap (res) => W.map(res, compile_single_views.bind(@))
 
     ###*
@@ -112,6 +113,17 @@ module.exports = (opts) ->
       if not obj.options.hook then return obj
       obj.data = obj.options.hook(obj.data)
       return obj
+    ###*
+     * If a write string option was provided in the config, write out the retrieved data to the configured file for later usage in the generated site.
+     *
+     * @param {String} obj - record object with a `key`, `options`, and `data`
+     ###
+
+    write_hook = (obj) ->
+      if not obj.options.write then return
+      # Maybe one needs it not only for urls - so ignore this check
+      # if not obj.options.url then throw new Error("Writing fetched JSON Data to a file does only make sense on urls, he? So please provide a 'url' option")
+      return this.util.write(opts.write, JSON.stringify(obj.data));
 
     ###*
      * Given a resolved records object, adds it to the view's locals.


### PR DESCRIPTION
Added a write_hook and a write option to export retrieved JSON Data (currently resolved by any type) to a public file. I use it quite often when needing to access the Data on Runtime of the static site again via JS.
